### PR TITLE
Update CPO200 disks

### DIFF
--- a/CPO200/disks/README.md
+++ b/CPO200/disks/README.md
@@ -161,6 +161,13 @@ Updated [https://www.googleapis.com/compute/v1/projects/cpo200demo1/zones/us-cen
 ```
 
 ```
+# Diskの状態をきれいに保つためにシャットダウンする
+gcloud compute instances stop sample --zone us-central1-b
+
+Updated [https://www.googleapis.com/compute/v1/projects/cpo200demo1/zones/us-central1-b/instances/sample].
+```
+
+```
 gcloud compute instances delete sample --zone us-central1-b
 
 Deleted [https://www.googleapis.com/compute/v1/projects/cpo200demo1/zones/us-central1-b/instances/sample].


### PR DESCRIPTION
Instance削除前に、Instanceをシャットダウンする記述を追加

Instanceを起動した状態で、Instanceを削除するとBootDiskが中途半端な状態になって、Custom Image作成後に正常に動かないことがあるので、Instance削除前にシャットダウンするようにした。